### PR TITLE
Add static list service discovery config

### DIFF
--- a/client-side-load-balancer/round-robin/pom.xml
+++ b/client-side-load-balancer/round-robin/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-client-side-load-balancer-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/client-side-load-balancer/round-robin/src/test/java/io/smallrye/loadbalancer/roundrobin/RoundRobinLoadBalancerTest.java
+++ b/client-side-load-balancer/round-robin/src/test/java/io/smallrye/loadbalancer/roundrobin/RoundRobinLoadBalancerTest.java
@@ -1,22 +1,23 @@
 package io.smallrye.loadbalancer.roundrobin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.junit.jupiter.api.Test;
+
 import io.smallrye.discovery.ServiceDiscovery;
 import io.smallrye.discovery.ServiceInstance;
 import io.smallrye.loadbalancer.LoadBalancer;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class RoundRobinLoadBalancerTest {
 
     private final ServiceDiscovery serviceDiscovery = new TestServiceDiscovery(
-            Arrays.asList(new ServiceInstance(1, "service-1-url"),
-                    new ServiceInstance(2, "service-2-url")));
+            Arrays.asList(new ServiceInstance("1", "service-1-url"),
+                    new ServiceInstance("2", "service-2-url")));
 
     @Test
     public void shouldGetServiceInstance() {
@@ -24,8 +25,8 @@ public class RoundRobinLoadBalancerTest {
         ServiceInstance oneInstance = loadBalancer.getServiceInstance().toCompletableFuture().join();
         ServiceInstance anotherInstance = loadBalancer.getServiceInstance().toCompletableFuture().join();
 
-        assertThat(oneInstance.getId()).isEqualTo(1);
-        assertThat(anotherInstance.getId()).isEqualTo(2);
+        assertThat(oneInstance.getId()).isEqualTo("1");
+        assertThat(anotherInstance.getId()).isEqualTo("2");
     }
 
     @Test
@@ -34,8 +35,8 @@ public class RoundRobinLoadBalancerTest {
         ServiceInstance oneInstance = loadBalancer.getServiceInstanceBlocking().get();
         ServiceInstance anotherInstance = loadBalancer.getServiceInstanceBlocking().get();
 
-        assertThat(oneInstance.getId()).isEqualTo(1);
-        assertThat(anotherInstance.getId()).isEqualTo(2);
+        assertThat(oneInstance.getId()).isEqualTo("1");
+        assertThat(anotherInstance.getId()).isEqualTo("2");
     }
 
     private static class TestServiceDiscovery implements ServiceDiscovery {

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>smallrye-load-balancer-parent</artifactId>
+        <groupId>io.smallrye</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>smallrye-load-balancer-config</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/src/main/java/io/smallrye/config/access/ServiceConfigAccessor.java
+++ b/config/src/main/java/io/smallrye/config/access/ServiceConfigAccessor.java
@@ -1,0 +1,43 @@
+package io.smallrye.config.access;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public class ServiceConfigAccessor {
+
+    private final Config config;
+
+    private final String prefix;
+
+    public ServiceConfigAccessor(String prefix) {
+        this(ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader()), prefix);
+    }
+
+    public ServiceConfigAccessor(Config config, String prefix) {
+        this.config = config;
+        this.prefix = prefix;
+    }
+
+    public String getValue(String serviceName, String key) {
+        return getValue(serviceName, key, String.class);
+    }
+
+    public <T> T getValue(String serviceName, String key, Class<T> type) {
+        String fullKey = String.format("%s.%s.%s", prefix, serviceName, key);
+
+        return config.getValue(fullKey, type);
+    }
+
+    public List<String> getKeys(String serviceName) {
+        String servicePrefix = String.format("%s.%s.", prefix, serviceName);
+
+        return StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .filter(name -> name.startsWith(servicePrefix))
+                .map(name -> name.replace(servicePrefix, ""))
+                .collect(Collectors.toList());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~  Copyright 2017 Red Hat, Inc.
+ ~  Copyright 2021 Red Hat, Inc.
  ~
  ~  Licensed under the Apache License, Version 2.0 (the "License");
  ~  you may not use this file except in compliance with the License.
@@ -35,14 +35,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
+        <version.assertj>3.19.0</version.assertj>
         <version.microprofile-config-api>2.0</version.microprofile-config-api>
-        <version.slf4j-simple>1.7.30</version.slf4j-simple>
-        <!-- smallrye-config is purely used for testing -->
         <version.smallrye-config>2.2.0</version.smallrye-config>
-        <!-- smallrye-metrics is purely used for testing -->
-        <version.smallrye-metrics>3.0.3</version.smallrye-metrics>
-
-        <version.org.assertj.assertj-core>3.19.0</version.org.assertj.assertj-core>
     </properties>
 
     <issueManagement>
@@ -57,14 +52,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <modules>
-        <module>api</module>
-        <module>implementation</module>
-        <module>testsuite</module>
-        <module>service-discovery</module>
-        <module>client-side-load-balancer</module>
-    </modules>
-
     <dependencyManagement>
         <!--mstodo clean up-->
         <dependencies>
@@ -78,53 +65,67 @@
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${version.microprofile-config-api}</version>
             </dependency>
-
-            <dependency>
-                <groupId>io.opentracing</groupId>
-                <artifactId>opentracing-mock</artifactId>
-                <version>${version.opentracing}</version>
-                <scope>test</scope>
-            </dependency>
-
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${version.smallrye-config}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${version.slf4j-simple}</version>
-                <scope>test</scope>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj}</version>
             </dependency>
 
             <!-- Dependencies provided by the project -->
             <dependency>
                 <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-load-balancer-config</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-service-discovery-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-service-discovery-static-list</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-client-side-load-balancer-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-client-side-load-balancer-round-robin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-load-balancer-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-load-balancer-implementation</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
-
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-load-balancer-testsuite</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
-
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${version.org.assertj.assertj-core}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <modules>
+        <module>api</module>
+        <module>implementation</module>
+        <module>testsuite</module>
+        <module>service-discovery</module>
+        <module>client-side-load-balancer</module>
+        <module>config</module>
+    </modules>
 </project>

--- a/service-discovery/api/src/main/java/io/smallrye/discovery/ServiceInstance.java
+++ b/service-discovery/api/src/main/java/io/smallrye/discovery/ServiceInstance.java
@@ -1,16 +1,16 @@
 package io.smallrye.discovery;
 
 public class ServiceInstance {
-    private final long id;
+    private final String id;
 
     private final String value;
 
-    public ServiceInstance(long id, String value) {
+    public ServiceInstance(String id, String value) {
         this.id = id;
         this.value = value;
     }
 
-    public long getId() {
+    public String getId() {
         return id;
     }
 

--- a/service-discovery/static-list/pom.xml
+++ b/service-discovery/static-list/pom.xml
@@ -14,7 +14,8 @@
  ~  See the License for the specific language governing permissions and
  ~  limitations under the License.
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -31,7 +32,25 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-service-discovery-api</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-load-balancer-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/service-discovery/static-list/src/main/java/io/smallrye/discovery/StaticListServiceDiscoveryProducer.java
+++ b/service-discovery/static-list/src/main/java/io/smallrye/discovery/StaticListServiceDiscoveryProducer.java
@@ -1,11 +1,49 @@
 package io.smallrye.discovery;
 
-import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.smallrye.config.access.ServiceConfigAccessor;
 
 public class StaticListServiceDiscoveryProducer implements ServiceDiscoveryProducer {
 
+    public static final String SERVICE_DISCOVERY_TYPE = "static";
+
+    public static final String CONFIG_PREFIX = "service-discovery";
+
+    private static final String CONFIG_KEY_TYPE = "type";
+
+    private final ServiceConfigAccessor serviceConfigAccessor;
+
+    public StaticListServiceDiscoveryProducer() {
+        this(new ServiceConfigAccessor(CONFIG_PREFIX));
+    }
+
+    public StaticListServiceDiscoveryProducer(ServiceConfigAccessor serviceConfigAccessor) {
+        this.serviceConfigAccessor = serviceConfigAccessor;
+    }
+
     public StaticListServiceDiscovery getServiceDiscovery(String serviceName) {
-        // TODO load the addresses from the configuration
-        return new StaticListServiceDiscovery(Collections.emptyList());
+        if (!SERVICE_DISCOVERY_TYPE.equals(serviceConfigAccessor.getValue(serviceName, CONFIG_KEY_TYPE))) {
+            throw new IllegalArgumentException("Static list service discovery is not enabled for this service");
+        }
+
+        List<ServiceInstance> serviceInstances = new LinkedList<>();
+        for (String id : getServiceIds(serviceName)) {
+            String value = serviceConfigAccessor.getValue(serviceName, id);
+            if (value != null) {
+                serviceInstances.add(new ServiceInstance(id, value));
+            }
+        }
+
+        return new StaticListServiceDiscovery(serviceInstances);
+    }
+
+    private List<String> getServiceIds(String serviceName) {
+        return serviceConfigAccessor.getKeys(serviceName)
+                .stream()
+                .filter(key -> !CONFIG_KEY_TYPE.equals(key))
+                .collect(Collectors.toList());
     }
 }

--- a/service-discovery/static-list/src/test/java/io/smallrye/discovery/StaticListServiceDiscoveryTest.java
+++ b/service-discovery/static-list/src/test/java/io/smallrye/discovery/StaticListServiceDiscoveryTest.java
@@ -1,0 +1,62 @@
+package io.smallrye.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.ConfigValuePropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.access.ServiceConfigAccessor;
+
+public class StaticListServiceDiscoveryTest {
+
+    private ServiceDiscoveryProducer serviceDiscoveryProducer;
+
+    @BeforeEach
+    void setUp() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("service-discovery.first-service.type", "static");
+        properties.put("service-discovery.first-service.1", "http://localhost:8080");
+        properties.put("service-discovery.first-service.2", "http://localhost:8081");
+        properties.put("service-discovery.second-service.type", "static");
+        properties.put("service-discovery.second-service.3", "http://localhost:8082");
+        properties.put("service-discovery.third-service.type", "kubernetes");
+        properties.put("service-discovery.third-service.4", "http://localhost:8083");
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new ConfigValuePropertiesConfigSource(properties, "test-config-source", 0))
+                .build();
+
+        serviceDiscoveryProducer = new StaticListServiceDiscoveryProducer(
+                new ServiceConfigAccessor(config, StaticListServiceDiscoveryProducer.CONFIG_PREFIX));
+    }
+
+    @Test
+    void shouldGetServiceDiscoveryWithMultipleInstances() {
+        ServiceDiscovery serviceDiscovery = serviceDiscoveryProducer.getServiceDiscovery("first-service");
+
+        assertThat(serviceDiscovery.getServiceInstancesBlocking()).hasSize(2);
+    }
+
+    @Test
+    void shouldGetServiceDiscoveryWithSingleInstance() {
+        ServiceDiscovery serviceDiscovery = serviceDiscoveryProducer.getServiceDiscovery("second-service");
+        List<ServiceInstance> serviceInstances = serviceDiscovery.getServiceInstancesBlocking();
+
+        assertThat(serviceInstances).hasSize(1);
+        assertThat(serviceInstances.get(0).getId()).isEqualTo("3");
+        assertThat(serviceInstances.get(0).getValue()).isEqualTo("http://localhost:8082");
+    }
+
+    @Test
+    void shouldNotGetWronglyConfiguredServiceDiscovery() {
+        assertThatThrownBy(() -> serviceDiscoveryProducer.getServiceDiscovery("third-service")).isInstanceOf(
+                IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Added a `ServiceConfigAccessor` based on your `ConfigView` just with a little more logic because it doesn't implement the `Config` interface. And updated the static list service discovery to use it when loading the service instances.